### PR TITLE
Add MISP deployment script

### DIFF
--- a/setup_platform/resources/misp/.env
+++ b/setup_platform/resources/misp/.env
@@ -1,0 +1,4 @@
+# Default MISP version to deploy
+MISP_VERSION=2.4.176
+# Optional image tag override
+MISP_TAG=2.4.176

--- a/setup_platform/resources/misp/README.md
+++ b/setup_platform/resources/misp/README.md
@@ -1,0 +1,3 @@
+This directory intentionally remains mostly empty. The `misp.sh` deployment script clones
+and uses the official `misp-docker` repository which already provides the compose files
+and environment configuration. Any custom variables can be set in `setup_platform/resources/default.env`.

--- a/setup_platform/scripts/apps/misp.sh
+++ b/setup_platform/scripts/apps/misp.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Deploy MISP using the official misp-docker repository
+set -e
+
+source "./libs/main.sh"
+define_env
+define_paths
+source "./libs/install-helper.sh"
+
+service_name="misp"
+
+MISP_VERSION=${MISP_VERSION:-"2.4.176"}
+
+printf "Cloning misp-docker repository with tag %s...\n" "$MISP_VERSION"
+if [ -d "${workdir}/${service_name}" ]; then
+  print_red "The directory ${workdir}/${service_name} already exists. Please remove it before running the script."
+  print_yellow "./cleanup.sh --app ${service_name}"
+  exit 1
+fi
+
+git clone --branch "$MISP_VERSION" --single-branch --depth 1 \
+  https://github.com/MISP/misp-docker "${workdir}/${service_name}"
+
+pre_install "$service_name" false
+
+cd "${workdir}/${service_name}"
+
+# Use provided .env file from the repository
+# If a local configuration exists in resources/misp/.env copy it first
+if [ -f "$src_dir/.env" ]; then
+  cp "$src_dir/.env" .
+fi
+if [ ! -f .env ] && [ -f .env.sample ]; then
+  cp .env.sample .env
+fi
+
+if [ ! -f .env ] && [ -f example.env ]; then
+  cp example.env .env
+fi
+
+if [ ! -f .env ]; then
+  print_yellow ".env file not found in the misp-docker repository"
+  touch .env
+fi
+
+replace_envs "${workdir}/${service_name}/.env"
+
+printf "Starting the service...\n"
+docker compose up -d --force-recreate
+
+print_green_v2 "$service_name deployment started" "successfully"
+


### PR DESCRIPTION
## Summary
- add a new app script `misp.sh` that clones the official `misp-docker` repo
- add minimal resources folder for MISP

## Testing
- `shellcheck` *(fails: command not found)*